### PR TITLE
Table populate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.10.1 (16/3/2022)
+Implements *TableBuilder* population methods:
+* `populateContent` to populate all the contents of a table
+* `buildContent` to get a matrix with only the contents of a table
+* `withCells` to create a xy table
+
+Implements `populateContent` also on the `Table` class.
+
 ## 1.9.1 (16/3/2022)
 Solves *Table* persistence issues with cells. Adds new useful methods to *Table* for:
 * Count columns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.9.1 (16/3/2022)
+Solves *Table* persistence issues with cells. Adds new useful methods to *Table* for:
+* Count columns
+* Count rows
+* Get a `Matrix2D` helper for managing table cells
+
 ## 1.8.2 (1/3/2022)
 
 Implements *Table*.*toBuilder* method to create a *TableBuilder* starting from

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022. Revo Digital
+ * ---
+ * Author: gabriele
+ * File: babel.config.cjs
+ * Project: complex-shapes-dev
+ * Committed last: 2022/3/16 @ 1732
+ * ---
+ * Description:
+ */
+
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-typescript',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revodigital/pamela",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "author": "Revo Digital",
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revodigital/pamela",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "author": "Revo Digital",
   "files": [
     "README.md",
@@ -16,7 +16,7 @@
     "start": "npx serve && npx cypress open",
     "doc": "npx typedoc",
     "doc-watch": "npx typedoc --watch",
-    "build": "npm run clean && tsc && cp ./src/index-types.d.ts ./lib/",
+    "build": "npm run test && npm run clean && tsc && cp ./src/index-types.d.ts ./lib/",
     "clean": "rm -rf ./lib ./types ./test-build",
     "serve": "npx serve -l 12345",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revodigital/pamela",
-  "version": "1.8.4",
+  "version": "1.8.10",
   "author": "Revo Digital",
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revodigital/pamela",
-  "version": "1.8.10",
+  "version": "1.9.1",
   "author": "Revo Digital",
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "build": "npm run clean && tsc && cp ./src/index-types.d.ts ./lib/",
     "clean": "rm -rf ./lib ./types ./test-build",
     "serve": "npx serve -l 12345",
-    "test": "npx cypress open"
+    "test": "jest"
   },
   "targets": {
     "none": {}
   },
   "dependencies": {
     "@ts-stack/markdown": "^1.4.0",
+    "@types/jest": "^27.4.1",
     "canvas": "^2.8.0",
     "chai": "4.3.4",
     "filehound": "^1.17.5",
@@ -49,12 +50,13 @@
     "typedoc-plugin-missing-exports": "^0.22.6"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.16.7",
     "@parcel/transformer-image": "2.0.0-beta.2",
     "@size-limit/preset-big-lib": "^5.0.4",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.13",
     "cypress-plugin-snapshots": "^1.4.4",
-    "jest": "^27.4.7",
+    "jest": "^27.5.1",
     "js-base64": "^2.5.2",
     "mocha": "8.4.0",
     "mocha-headless-chrome": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revodigital/pamela",
-  "version": "1.9.1",
+  "version": "1.10.1",
   "author": "Revo Digital",
   "files": [
     "README.md",

--- a/src/builders/CellCollectionBuilder.ts
+++ b/src/builders/CellCollectionBuilder.ts
@@ -71,6 +71,14 @@ export abstract class CellCollectionBuilder implements Builder<CellConfig[]> {
   }
 
   /**
+   * Merges 2 consequent cells using their indexes
+   * @param indexA
+   * @param indexB
+   * @param useA
+   */
+  abstract mergeCells(indexA: number, indexB: number, useA: boolean);
+
+  /**
    * Checks if all the cells have auto width
    */
   hasAutoWidth(): boolean {
@@ -101,6 +109,67 @@ export abstract class CellCollectionBuilder implements Builder<CellConfig[]> {
     this.cells.forEach(it => {
       it.autoWidth = true;
     });
+
+    return this;
+  }
+
+  /**
+   * Removes a cell at the specified index
+   * @param index Cell index
+   */
+  removeCellAt(index: number): this {
+    if (!this.hasCellAtIndex(index)) return this;
+
+    this.cells.splice(index, 1);
+
+    return this;
+  }
+
+  /**
+   * Overwrites the configuration of a cell
+   * @param index Index of the cell
+   * @param config Configuration to set
+   */
+  overwrite(index: number, config: CellConfig): this {
+    if (!this.hasCellAtIndex(index)) return this;
+
+    this.cells[index] = config;
+
+    return this;
+  }
+
+  /**
+   * Returns the last index
+   */
+  lastIndex(): number {
+    const last = this.cells.length - 1;
+    return last >= 0 ? last : 0;
+  }
+
+  /**
+   * Overwrites the first cell
+   * @param config
+   */
+  overwriteFirst(config: CellConfig): this {
+    return this.overwrite(0, config);
+  }
+
+  /**
+   * Overwrites the last cell
+   * @param config
+   */
+  overwriteLast(config: CellConfig): this {
+    return this.overwrite(this.lastIndex(), config);
+  }
+
+  /**
+   * Removes every cell that fits to this predicate
+   * @param predicate When it returns true, the cell gets removed
+   */
+  removeWhere(predicate: (cell: CellConfig, index: number, cellsCount: number) => boolean): this {
+    for (let i = 0; i < this.cells.length; i++)
+      if (predicate(this.cells[i], i, this.cells.length))
+        this.cells.splice(i);
 
     return this;
   }
@@ -465,7 +534,7 @@ export abstract class CellCollectionBuilder implements Builder<CellConfig[]> {
    * @param config
    */
   setLast(config: Partial<CellConfig>): void {
-    Object.assign(this.cells[this.cells.length - 1], config);
+    Object.assign(this.cells[this.lastIndex()], config);
   }
 
   /**

--- a/src/builders/ColumnBuilder.ts
+++ b/src/builders/ColumnBuilder.ts
@@ -74,6 +74,41 @@ export class ColumnBuilder extends CellCollectionBuilder {
   }
 
   /**
+   * Merges 2 cells, by index. The resulting cell will have the same width as the original ones
+   * but a summed height. Please note that they must be consecutive.
+   * Not yet implemented
+   * @param indexA First cell index
+   * @param indexB Second cell index
+   * @param useA Indicates if the style should be inherited from a or b
+   */
+  mergeCells(indexA: number, indexB: number, useA: boolean) {
+    // const distance = Math.abs(indexA - indexB);
+    // // The cells are not consecutive
+    // if (distance > 1) return;
+    // if (!this.hasCellAtIndex(indexA) || !this.hasCellAtIndex(indexB)) return;
+    //
+    // // Cell to remove
+    // const indexToRemove = useA ? indexB : indexA;
+    // // Cell to copy to
+    // const indexCopy = useA ? indexA : indexB;
+    //
+    // const temp = this.get(indexCopy);
+    // const tempRem = this.get(indexToRemove);
+    //
+    // this.overwrite(indexCopy, this.get(indexToRemove));
+    // this.set(indexCopy, {
+    //   height: temp.height + tempRem.height,
+    //   autoHeight: false
+    // });
+    //
+    // // Remove other cell
+    // this.removeCellAt(indexToRemove);
+    //
+    // return this
+    return this;
+  }
+
+  /**
    * Creates a new row with a given number of cells with the same configuration
    * @param num Number of cells
    * @param config Configuration to apply to all of them

--- a/src/builders/RowBuilder.ts
+++ b/src/builders/RowBuilder.ts
@@ -32,7 +32,7 @@ export class RowBuilder extends CellCollectionBuilder {
 
     console.log(total);
     const part = total / this.getAutoWidthCellsCount();
-    console.log("Part is ", part);
+    console.log('Part is ', part);
 
     return this.setAllAutoWidthCells({
       width: part
@@ -89,6 +89,39 @@ export class RowBuilder extends CellCollectionBuilder {
 
         index++;
       });
+
+    return this;
+  }
+
+  /**
+   * Merges 2 cells, by index. The resulting cell will have the same width as the original ones
+   * but a summed height. Please note that they must be consecutive
+   * @param indexA First cell index
+   * @param indexB Second cell index
+   * @param useA Indicates if the style should be inherited from a or b
+   */
+  mergeCells(indexA: number, indexB: number, useA: boolean): this {
+    const distance = Math.abs(indexA - indexB);
+    // The cells are not consecutive
+    if (distance > 1) return this;
+    if (!this.hasCellAtIndex(indexA) || !this.hasCellAtIndex(indexB)) return this;
+
+    // Cell to remove
+    const indexToRemove = useA ? indexB : indexA;
+    // Cell to copy to
+    const indexCopy = useA ? indexA : indexB;
+
+    const temp = this.get(indexCopy);
+    const tempRem = this.get(indexToRemove);
+
+    this.overwrite(indexCopy, this.get(indexToRemove));
+    this.set(indexCopy, {
+      width: temp.width + tempRem.width,
+      autoWidth: false
+    });
+
+    // Remove other cell
+    this.removeCellAt(indexToRemove);
 
     return this;
   }

--- a/src/builders/RowBuilder.ts
+++ b/src/builders/RowBuilder.ts
@@ -30,9 +30,7 @@ export class RowBuilder extends CellCollectionBuilder {
   fitWidth(totalPerc?: number): this {
     const total = this.getFreeWidth();
 
-    console.log(total);
     const part = total / this.getAutoWidthCellsCount();
-    console.log('Part is ', part);
 
     return this.setAllAutoWidthCells({
       width: part

--- a/src/builders/TableBuilder.ts
+++ b/src/builders/TableBuilder.ts
@@ -768,7 +768,7 @@ export class TableBuilder implements Builder<Table> {
    */
   static fromTable(table: Table): TableBuilder {
     const b = new TableBuilder(table.toConfig());
-    b.setCells(table.cells());
+    b.setCells(new Matrix2D<CellConfig>(table.cells()));
 
     return b;
   }
@@ -787,7 +787,7 @@ export class TableBuilder implements Builder<Table> {
    * @param table
    */
   buildTo(table: Table): void {
-    table.cells(this.cells);
+    table.cells(this.cells.data);
   }
 
   /**
@@ -796,7 +796,7 @@ export class TableBuilder implements Builder<Table> {
   build(): Table {
     return new Table({
       ...this.options,
-      cells: this.cells
+      cells: this.cells.data
     });
   }
 }

--- a/src/builders/TableBuilder.ts
+++ b/src/builders/TableBuilder.ts
@@ -511,6 +511,26 @@ export class TableBuilder implements Builder<Table> {
   }
 
   /**
+   * Construct a new table giving complete number of cells (5x5)
+   * @param x Number of cells per row
+   * @param y Number of rows
+   * @param shapeConfig Initial shape configuration
+   * @param cellConfig Cell configuration to apply to all the cells
+   */
+  static withCells(x: number, y: number, shapeConfig?: TableConfig, cellConfig?: Partial<CellConfig>): TableBuilder {
+    let builder = new TableBuilder(shapeConfig);
+
+    if (x <= 0 || y <= 0) return builder;
+
+    for (let i = 0; i < y; i++)
+      builder.addRow({
+        row: RowBuilder.withCells(x, cellConfig)
+      });
+
+    return builder;
+  }
+
+  /**
    * Sets the background of a specific range of columns
    * @param color Background color
    * @param start Start index
@@ -788,6 +808,39 @@ export class TableBuilder implements Builder<Table> {
    */
   buildTo(table: Table): void {
     table.cells(this.cells.data);
+  }
+
+  /**
+   * Builds all the cells of this table to a matrix containing
+   * only their content
+   */
+  buildContent(): Matrix2D<string> {
+    return this.getMatrix().map<string>(it => it.content);
+  }
+
+  /**
+   * Populates the content of a Table
+   * @param content A matrix containing only the contents of the string
+   * @param includesHeader Should it start from the header or skip to the next row?
+   */
+  populateContent(content: Matrix2D<string>, includesHeader?: boolean): this {
+    const headered = !!includesHeader;
+    let rowIndex = headered ? 0 : 1;
+
+    content.forEachRow(row => {
+      let index = 0;
+
+      const r = this.cells.getRow(rowIndex);
+      if (r !== undefined)
+        r.forEach(it => {
+          it.content = row[index] || '';
+          index++;
+        });
+
+      rowIndex++;
+    });
+
+    return this;
   }
 
   /**

--- a/src/common/Matrix2D.ts
+++ b/src/common/Matrix2D.ts
@@ -19,7 +19,7 @@ export class MatrixIndex extends Point2D {}
  * Represents a bidimensional matrix
  */
 export class Matrix2D<T> {
-  private data: T[][];
+  data: T[][];
 
   constructor(data?: T[][]) {
     this.data = data || [];

--- a/src/common/Matrix2D.ts
+++ b/src/common/Matrix2D.ts
@@ -15,6 +15,39 @@ import { insertToArray } from '../shapes/utils';
 
 export class MatrixIndex extends Point2D {}
 
+export const matrixOf = <T>(data: T[][]): Matrix2D<T> => {
+  return new Matrix2D<T>(data);
+};
+
+/**
+ * Creates a repeated array
+ * @param sample
+ * @param length
+ */
+export const arrayRepeat = <T>(sample: T, length: number): T[] => {
+  let a = [];
+
+  for (let i = 0; i < length; i++)
+    a.push(sample);
+
+  return a;
+};
+
+/**
+ * Creates a repeated matrix
+ * @param sample
+ * @param width
+ * @param height
+ */
+export const matrixRepeat = <T>(sample: T, width: number, height: number): Matrix2D<T> => {
+  let matrix = new Matrix2D<T>();
+
+  for (let i = 0; i < height; i++)
+    matrix.pushRow(arrayRepeat(sample, width));
+
+  return matrix;
+};
+
 /**
  * Represents a bidimensional matrix
  */
@@ -33,6 +66,25 @@ export class Matrix2D<T> {
     if (!this.hasCellAtIndex(index)) return undefined;
 
     else return this.data[index.y][index.x];
+  }
+
+  /**
+   * Map a matrix to a new matrix of another type
+   * @param converter
+   */
+  public map<Y>(converter: (cell: T) => Y): Matrix2D<Y> {
+    let result = new Matrix2D<Y>();
+
+    this.forEachRow(row => {
+      let r = [];
+      row.forEach(cell => {
+        r.push(converter(cell));
+      });
+
+      result.pushRow(r);
+    });
+
+    return result;
   }
 
   /**
@@ -258,7 +310,7 @@ export class Matrix2D<T> {
 
   insertColumn(object: T[], startIndex: number, verse: Verse) {
     let i = 0;
-    console.log("initial data: ", this.data);
+    console.log('initial data: ', this.data);
 
     for (let c = 0; c < this.getRowsCount(); c++) {
       this.data[c] = insertToArray(this.data[c], object[i], startIndex, verse);

--- a/src/shapes/Table.ts
+++ b/src/shapes/Table.ts
@@ -22,7 +22,7 @@ import { PointRectangle2D }   from '../common/PointRectangle2D';
 import { TableBuilder }       from '../builders/TableBuilder';
 
 export interface TableConfig extends ShapeConfig {
-  cells?: Matrix2D<CellConfig>;
+  cells?: CellConfig[][];
 }
 
 /**
@@ -32,7 +32,7 @@ export class Table extends Shape<TableConfig> {
   /**
    * Contains all the cells of this Table
    */
-  cells: GetSet<Matrix2D<CellConfig>, this>;
+  cells: GetSet<CellConfig[][], this>;
   _config: TableConfig;
 
   constructor(config: TableConfig) {
@@ -75,7 +75,9 @@ export class Table extends Shape<TableConfig> {
     const width = this.width();
     const height = this.height();
 
-    this.cells().forEachRow(it => {
+    const cells = new Matrix2D<CellConfig>(this.cells());
+
+    cells.forEachRow(it => {
       // Skip empty lines
       if (it.length <= 0) return;
 
@@ -100,6 +102,32 @@ export class Table extends Shape<TableConfig> {
 
       offsetY += (it[0].height / 100) * height;
     });
+  }
+
+  /**
+   * Returns the number of columns into this table
+   */
+  countColumns(): number {
+    if (this.cells().length === 0) return 0;
+
+    return this.cells()[0].length;
+  }
+
+  /**
+   * Returns the number of rows into this table
+   */
+  countRows(): number {
+    return this.cells().length;
+  }
+
+  /**
+   * Returns an helper to work easily with the cells of this matrix.
+   *
+   * Your code **should not** change the cells, but only perform calculations.
+   * To edit a table, please use `TableBuilder` class instead
+   */
+  getCellsMatrix(): Matrix2D<CellConfig> {
+    return new Matrix2D<CellConfig>(this.cells());
   }
 
   /**

--- a/src/shapes/Table.ts
+++ b/src/shapes/Table.ts
@@ -76,6 +76,9 @@ export class Table extends Shape<TableConfig> {
     const height = this.height();
 
     this.cells().forEachRow(it => {
+      // Skip empty lines
+      if (it.length <= 0) return;
+
       let offsetX = 0;
 
       it.forEach(cell => {

--- a/src/shapes/Table.ts
+++ b/src/shapes/Table.ts
@@ -121,6 +121,31 @@ export class Table extends Shape<TableConfig> {
   }
 
   /**
+   * Populates the contents of a table
+   * @param content
+   * @param includesHeader
+   */
+  populateContent(content: Matrix2D<string>, includesHeader?: boolean): this {
+    const headered = !!includesHeader;
+    let rowIndex = headered ? 0 : 1;
+
+    content.forEachRow(row => {
+      let index = 0;
+
+      const r = this.cells[rowIndex];
+      if (r !== undefined)
+        r.forEach(it => {
+          it['content'] = row[index] || '';
+          index++;
+        });
+
+      rowIndex++;
+    });
+
+    return this;
+  }
+
+  /**
    * Returns an helper to work easily with the cells of this matrix.
    *
    * Your code **should not** change the cells, but only perform calculations.

--- a/src/shapes/Table.ts
+++ b/src/shapes/Table.ts
@@ -121,9 +121,11 @@ export class Table extends Shape<TableConfig> {
   }
 
   /**
-   * Populates the contents of a table
-   * @param content
-   * @param includesHeader
+   * Populates the contents of a table starting from a matrix. The table is populated according to the input matrix size.
+   * If you supply a 10x10 matrix to populate a 100x100 table, only the first 10x10 cells will be populated, the other will
+   * be leaved empty. The same happens if the supplied matrix is too big, only the required part will be used
+   * @param content The matrix to use for population
+   * @param includesHeader Should this operation start from the header or not? If false it will start from the row 1
    */
   populateContent(content: Matrix2D<string>, includesHeader?: boolean): this {
     const headered = !!includesHeader;
@@ -132,10 +134,13 @@ export class Table extends Shape<TableConfig> {
     content.forEachRow(row => {
       let index = 0;
 
-      const r = this.cells[rowIndex];
+      let r = this.cells()[rowIndex];
       if (r !== undefined)
         r.forEach(it => {
-          it['content'] = row[index] || '';
+          const content = row[index];
+
+          if (content)
+            it['content'] = row[index] || '';
           index++;
         });
 
@@ -143,6 +148,27 @@ export class Table extends Shape<TableConfig> {
     });
 
     return this;
+  }
+
+  /**
+   * Returns the number of rows in this table. If it is empty
+   * it returns 0
+   */
+  getRowsCount(): number {
+    if (!this.cells()) return 0;
+
+    return this.cells().length;
+  }
+
+
+  /**
+   * Returns the number of column in this table
+   */
+  getColumnsCount(): number {
+    if (!this.cells) return 0;
+
+    if (!this.cells()[0]) return 0;
+    return this.cells()[0]?.length || 0;
   }
 
   /**
@@ -160,6 +186,13 @@ export class Table extends Shape<TableConfig> {
    */
   toBuilder(): TableBuilder {
     return TableBuilder.fromTable(this);
+  }
+
+  /**
+   * Builds the contents of this table to a matrix
+   */
+  buildContent(): Matrix2D<string> {
+    return this.toBuilder().buildContent();
   }
 
   /**

--- a/test/matrix.test.ts
+++ b/test/matrix.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022-2022. Revo Digital
+ * ---
+ * Author: gabriele
+ * File: matrix.test.ts
+ * Project: complex-shapes-dev
+ * Committed last: 2022/3/16 @ 1742
+ * ---
+ * Description:
+ */
+
+import { arrayRepeat, Matrix2D, matrixRepeat } from '../src/common/Matrix2D';
+
+it('Should correctly map this matrix', () => {
+  const matrix = new Matrix2D<number>([[5, 3], [3, 5]]);
+
+  const result = matrix.map(it => it.toFixed(2));
+
+  expect(result).toBeDefined();
+  expect(result.firstRow()).toEqual(['5.00', '3.00']);
+  expect(result.lastRow()).toEqual(['3.00', '5.00']);
+});
+
+it('Should correctly return an empty matrix', () => {
+  const matrix = new Matrix2D<number>([]);
+
+  const result = matrix.map(it => it + 5);
+
+  expect(result).toBeDefined();
+  expect(result.length()).toEqual(0);
+});
+
+it('Should correctly generate an matrix', () => {
+  const matrix = matrixRepeat('test', 20, 20);
+
+  expect(matrix.getRowsCount()).toEqual(20);
+  expect(matrix.getColumnsCount()).toEqual(20);
+  expect((matrix.firstRow() as any)[0]).toEqual('test');
+});
+
+it('Should correctly generate an array', () => {
+  const array = arrayRepeat(10, 200);
+  expect(array.length).toEqual(200);
+  expect(array[0]).toEqual(10);
+  expect(array[199]).toEqual(10);
+});

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,0 +1,21 @@
+import { TableBuilder } from '../src/builders/TableBuilder';
+import { RowBuilder }   from '../lib/builders/RowBuilder';
+
+it('should correctly return only the content of this table', () => {
+  const table = new TableBuilder();
+  table.addRow({
+    row: RowBuilder.withCells(100, {
+      bold: true,
+      content: 'hello',
+    }).autoWidth().autoHeight()
+  });
+
+  const onlyContent = table.buildContent();
+  expect(table.buildContent()).toBeDefined();
+  expect(onlyContent.getRowsCount()).toEqual(1);
+  expect(onlyContent.getColumnsCount()).toEqual(100);
+
+  onlyContent.forEachRow(row => {
+    row.forEach(cell => expect(cell).toEqual('hello'))
+  })
+});

--- a/test/tablebuilder.test.ts
+++ b/test/tablebuilder.test.ts
@@ -73,3 +73,22 @@ it('Should correctly create a 200x200 table', () => {
 
   expect(table.cells()[0][0]).toHaveProperty('content', 'hello');
 });
+
+it('Should correctly populate this existing table', () => {
+  const table = TableBuilder.withCells(100, 100, {
+    width: 100,
+    height: 100
+  }, { autoWidth: true, autoHeight: true, fill: 'white' }).build();
+
+  expect(table).toBeDefined();
+  expect(table.getRowsCount()).toEqual(100);
+  expect(table.getColumnsCount()).toEqual(100);
+
+  table.populateContent(matrixRepeat('content', 10, 10), false);
+
+  for (let i = 1; i <= 10; i++) {
+    expect(table.cells()[i]).toBeDefined();
+    for (let x = 0; x < 10; x++)
+      expect(table.cells()[i][x].content).toEqual('content');
+  }
+});

--- a/test/tablebuilder.test.ts
+++ b/test/tablebuilder.test.ts
@@ -71,7 +71,7 @@ it('Should correctly create a 200x200 table', () => {
 
   table.populateContent(matrixRepeat('hello', 200, 200));
 
-  expect(table.cells()[0][0]).toHaveProperty('content', 'hello');
+  expect(table.cells()[1][0].content).toEqual('hello');
 });
 
 it('Should correctly populate this existing table', () => {

--- a/test/tablebuilder.test.ts
+++ b/test/tablebuilder.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022. Revo Digital
+ * ---
+ * Author: gabriele
+ * File: tablebuilder.test.ts
+ * Project: complex-shapes-dev
+ * Committed last: 2022/3/16 @ 1852
+ * ---
+ * Description:
+ */
+
+import { TableBuilder }  from '../src/builders/TableBuilder';
+import { ColumnBuilder } from '../lib/builders/ColumnBuilder';
+import { RowBuilder }    from '../lib/builders/RowBuilder';
+import { matrixRepeat }  from '../src/common/Matrix2D';
+
+it('Should correctly populate this entire table', () => {
+  const builder = new TableBuilder({
+    width: 100,
+    height: 100
+  });
+
+  builder.addRow({
+    row: RowBuilder.withCells(100, {
+      bold: true,
+      fill: 'red'
+    })
+  });
+
+  const data = matrixRepeat('test', 100, 100);
+  builder.populateContent(data, true);
+
+  builder.build();
+  builder.buildContent();
+});
+
+it('should correctly generate this table', () => {
+  const builder = new TableBuilder({
+    width: 100,
+    height: 100
+  });
+
+  builder.addColumn({
+    column: ColumnBuilder.withCells(100, {
+      fill: 'blue'
+    })
+  });
+
+  builder.addColumn({
+    column: ColumnBuilder.withCells(100, {
+      fill: 'red'
+    })
+  });
+
+  expect(builder.buildContent()).toBeDefined();
+  expect(builder.getColumnsCount()).toEqual(2);
+  expect(builder.getRowsCount()).toEqual(100);
+  expect(builder.firstRow()).toBeDefined();
+  expect(builder.lastRow()).toBeDefined();
+  expect(builder.getRow(5)).toBeDefined();
+
+  expect(builder.firstRow()?.first()).toBeDefined();
+});
+
+it('Should correctly create a 200x200 table', () => {
+  const builder = TableBuilder.withCells(200, 200, { fill: 'red' });
+
+  const table = builder.build();
+
+  expect(table.cells()).toBeDefined();
+
+  table.populateContent(matrixRepeat('hello', 200, 200));
+
+  expect(table.cells()[0][0]).toHaveProperty('content', 'hello');
+});


### PR DESCRIPTION
## Description
Implements *TableBuilder* population methods:
* `populateContent` to populate all the contents of a table
* `buildContent` to get a matrix with only the contents of a table
* `withCells` to create a xy table

Implements `populateContent` also on the `Table` class.


Solves *Table* persistence issues with cells. Adds new useful methods to *Table* for:
* Count columns
* Count rows
* Get a `Matrix2D` helper for managing table cells

## Type of change
Implementations and bug fixes

## Known problems
All known noticeable problems should be listed here

## Deprecates
Every symbol that is no longer available

## Refactorings
Code refactorings