### PR TITLE
Table JSON methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,36 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.11.1 (17/3/2022)
+
+Implements *TableBuilder* methods to handle directly JSON strings. Now you can:
+
+* Create a table starting from the JSON (`TableBuilder.fromJSON()`)
+* Build a table to JSON (`builder.buildJSON()`)
+
+IMPORTANT NOTE: The structure of the JSON string is the same of the `Table`
+class. Normally, you can use a similar snippet to create and store a table to
+JSON easily:
+
+```typescript
+import { TableBuilder } from './TableBuilder';
+
+const builder = TableBuilder.withCells(100,
+  100,
+  { width: 200, height: 200 }).build()
+
+const json = builder.buildJSON()
+
+// Store your json
+```
+
+Please avoid creating the json by hand, it can lead to very stupid errors. Do
+use the `TableBuilder` for that purpose.
+
 ## 1.10.1 (16/3/2022)
+
 Implements *TableBuilder* population methods:
+
 * `populateContent` to populate all the contents of a table
 * `buildContent` to get a matrix with only the contents of a table
 * `withCells` to create a xy table
@@ -12,7 +40,10 @@ Implements *TableBuilder* population methods:
 Implements `populateContent` also on the `Table` class.
 
 ## 1.9.1 (16/3/2022)
-Solves *Table* persistence issues with cells. Adds new useful methods to *Table* for:
+
+Solves *Table* persistence issues with cells. Adds new useful methods to *Table*
+for:
+
 * Count columns
 * Count rows
 * Get a `Matrix2D` helper for managing table cells

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revodigital/pamela",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "author": "Revo Digital",
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revodigital/pamela",
-  "version": "1.10.3",
+  "version": "1.11.1",
   "author": "Revo Digital",
   "files": [
     "README.md",

--- a/src/builders/TableBuilder.ts
+++ b/src/builders/TableBuilder.ts
@@ -16,6 +16,7 @@ import { CellConfig }         from '../shapes/cell';
 import { RowBuilder }         from './RowBuilder';
 import { Verse }              from '../shapes/Verse';
 import { ColumnBuilder }      from './ColumnBuilder';
+import { Node }               from '../Node';
 
 export interface AddRowConfig {
   row: RowBuilder;
@@ -531,6 +532,26 @@ export class TableBuilder implements Builder<Table> {
   }
 
   /**
+   * Constructs a table starting from the JSON.
+   *
+   * @param json The json string to parse (it has to have the same structure of the Table class)
+   * @returns TableBuilder A table builder to perform operations on the loaded table
+   */
+  static fromJSON(json: string): TableBuilder {
+    let builder = new TableBuilder();
+
+    try {
+      const table = Node.create(json) as Table;
+
+      return TableBuilder.fromTable(table);
+    } catch (e) {
+
+    }
+
+    return builder;
+  }
+
+  /**
    * Sets the background of a specific range of columns
    * @param color Background color
    * @param start Start index
@@ -851,5 +872,12 @@ export class TableBuilder implements Builder<Table> {
       ...this.options,
       cells: this.cells.data
     });
+  }
+
+  /**
+   * Build directly a JSON string for this table
+   */
+  buildJSON(): string {
+    return this.build().toJSON();
   }
 }

--- a/src/shapes/Table.ts
+++ b/src/shapes/Table.ts
@@ -160,7 +160,6 @@ export class Table extends Shape<TableConfig> {
     return this.cells().length;
   }
 
-
   /**
    * Returns the number of column in this table
    */

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,5 +1,7 @@
 import { TableBuilder } from '../src/builders/TableBuilder';
 import { RowBuilder }   from '../lib/builders/RowBuilder';
+import Pamela           from '../lib';
+import { Table }        from '../src/shapes/Table';
 
 it('should correctly return only the content of this table', () => {
   const table = new TableBuilder();
@@ -16,6 +18,20 @@ it('should correctly return only the content of this table', () => {
   expect(onlyContent.getColumnsCount()).toEqual(100);
 
   onlyContent.forEachRow(row => {
-    row.forEach(cell => expect(cell).toEqual('hello'))
-  })
+    row.forEach(cell => expect(cell).toEqual('hello'));
+  });
+});
+
+it('The table should be correctly stored into JSON', () => {
+  const table = TableBuilder.withCells(20, 20, {
+    width: 100, height: 100,
+  }).build();
+
+  const json = table.toJSON();
+  const table2 = Pamela.Node.create(json) as Table;
+
+  expect(json).toBeDefined();
+  expect(table2).toBeDefined();
+  expect(table2.getColumnsCount()).toEqual(20);
+  expect(table2.getRowsCount()).toEqual(20);
 });

--- a/test/tablebuilder.test.ts
+++ b/test/tablebuilder.test.ts
@@ -92,3 +92,24 @@ it('Should correctly populate this existing table', () => {
       expect(table.cells()[i][x].content).toEqual('content');
   }
 });
+
+it('Should correctly load this table from the JSON', () => {
+  const table = TableBuilder.withCells(20, 20, {
+    width: 100,
+    height: 200,
+    fill: 'white',
+    stroke: 'black'
+  }).build();
+
+  const tableJson = table.toJSON();
+
+  const loadTable = TableBuilder.fromJSON(tableJson);
+  expect(loadTable.getRowsCount()).toEqual(20);
+  expect(loadTable.getColumnsCount()).toEqual(20);
+
+  const t = loadTable.build();
+  expect(loadTable.build()).toBeDefined();
+  expect(t.width()).toEqual(100);
+  expect(t.height()).toEqual(200);
+  expect(t.fill()).toEqual('white');
+});


### PR DESCRIPTION
## Description

Implements *TableBuilder* methods to handle directly JSON strings. Now you can:

* Create a table starting from the JSON (`TableBuilder.fromJSON()`)
* Build a table to JSON (`builder.buildJSON()`)

IMPORTANT NOTE: The structure of the JSON string is the same of the `Table`
class. Normally, you can use a similar snippet to create and store a table to
JSON easily:

```typescript
import { TableBuilder } from './TableBuilder';

const builder = TableBuilder.withCells(100,
  100,
  { width: 200, height: 200 }).build()

const json = builder.buildJSON()

// Store your json
```

Please avoid creating the json by hand, it can lead to very stupid errors. Do
use the `TableBuilder` for that purpose.

## Type of change
New implementations

## Known problems
All known noticeable problems should be listed here

## Deprecates
Every symbol that is no longer available

## Refactorings
Code refactorings